### PR TITLE
Moved a lot of repeated code and placed in functions instead

### DIFF
--- a/Logistics/WebContent/member.jsp
+++ b/Logistics/WebContent/member.jsp
@@ -18,89 +18,143 @@
 		document.getElementById('sliderVal1').innerHTML = sliderValue1;
 	}
 	
-	//function to reset sliders
-	//i.e. when the reset button is selected
-	function reset() {
+	
+	//function to reset train slider
+	function resetTrainSlider(){
+		
+		//set the train slider value to
+		//the sliders maximum value divided by 2
+		document.getElementById('rating').value = (document
+				.getElementById('rating').max / 2);
+		
+		//call function to update slider value on screen
+		evalSlider();
+	}
+	
+	
+	//function to reset tank slider
+	function resetTankSlider(){
+		
+		//set the tank slider value to
+		//the sliders maximum value divided by 2
+		document.getElementById('rating1').value = (document
+				.getElementById('rating1').max / 2);
+
+		//call function to update slider value on screen
+		evalSlider1();
+	}
+	
+	
+	//function to disable tank slider
+	function disableTankSlider(){
+		
+		//disable tank slider
+		//i.e. get disabled attribute and switch to true
+		document.getElementById('rating1').disabled = true;
+
+		//enable train slider
+		//i.e. get disabled attribute and switch to false
+		document.getElementById('rating').disabled = false;
+	}
+	
+	
+	//function to disable train slider
+	function disableTrainSlider(){
+		
+		//disable train slider
+		document.getElementById('rating').disabled = true;
+
+		//enable tank slider
+		document.getElementById('rating1').disabled = false;
+	}
+	
+
+	//function to run on train radio button selection
+	//i.e. when trains are selected
+	function trainRadioSelect() {
+
+		//if the tank slider is NOT disabled
+		//i.e if the disabled attribute is false
+		if (document.getElementById('rating1').disabled == false) {
+
+			//call function to disable tank
+			disableTankSlider();
+			
+			//call function to enable confirm button
+			enableConfirmBtn();
+			
+		}
+	}
+	
+	
+	//function to run on tank radio button selection
+	//i.e. when tanks are selected
+	function tankRadioSelect() {
+
+		//if the train slider is NOT disabled
+		if (document.getElementById('rating').disabled == false) {
+
+			//disable train slider
+			disableTrainSlider();
+			
+			//call function to enable confirm button
+			enableConfirmBtn();
+		}
+	}
+	
+	
+	//function to enable confirm button
+	//i.e. when a radio button is selected
+	function enableConfirmBtn(){
+		
+		//if the confirm button is disabled
+		//i.e. if the disabled attribute is true
+		if(document.getElementById('confirm').disabled == true){
+			
+			//switch to NOT disabled
+			document.getElementById('confirm').disabled = false;
+		}
+	}
+	
+	
+	//function to reset train + tank sliders
+	//i.e. run when the reset button is selected
+	function resetBtn() {
 
 		//if both sliders are NOT disabled
 		//i.e. when the page first loads
-		//reset both sliders
+		//then reset both sliders
 		if(document.getElementById('rating').disabled == false 
 				&& document.getElementById('rating1').disabled == false){
 			
-			//set the train slider value to
-			//the sliders maximum value divided by 2
-			document.getElementById('rating').value = (document
-					.getElementById('rating').max / 2);
-			
-			//call function to update slider value on screen
-			evalSlider();
-			
-			//set the tank slider value to
-			//the sliders maximum value divided by 2
-			document.getElementById('rating1').value = (document
-					.getElementById('rating1').max / 2);
-
-			//call function to update slider value on screen
-			evalSlider1();
-			
+			//call function to reset sliders
+			resetTrainSlider();
+			resetTankSlider();
 		}
 		
 		//else if the train slider is NOT disabled
 		//i.e. the user selects trains
 		else if (document.getElementById('rating').disabled == false) {
 
-			//set the train slider value to
-			//the sliders maximum value divided by 2
-			document.getElementById('rating').value = (document
-					.getElementById('rating').max / 2);
-
-			//call function to update slider value on screen
-			evalSlider();
+			//call function to reset train slider
+			resetTrainSlider();
 		}
 
 		//else the choice is tanks
 		else {
 
-			//set the tank slider value to
-			//the sliders maximum value divided by 2
-			document.getElementById('rating1').value = (document
-					.getElementById('rating1').max / 2);
-
-			//call function to update slider value on screen
-			evalSlider1();
+			//call function to reset tank slider
+			resetTankSlider();
 		}
 	}
 	
-
-	//function to disable tank selection
-	//i.e. when trains are selected
-	function trainSelect() {
-
-		//if the tank slider is NOT disabled
-		if (document.getElementById('rating1').disabled == false) {
-
-			//disable tank slider
-			document.getElementById('rating1').disabled = true;
-
-			//enable train slider
-			document.getElementById('rating').disabled = false;
-		}
-	}
-
-	//function to disable train selection
-	//i.e. when tanks are selected
-	function tankSelect() {
-
-		//if the train slider is NOT disabled
-		if (document.getElementById('rating').disabled == false) {
-
-			//disable train slider
-			document.getElementById('rating').disabled = true;
-
-			//enable tank slider
-			document.getElementById('rating1').disabled = false;
-		}
+	
+	//function to confirm vehicle selection
+	//i.e. when the confirm button is selected
+	function confirmBtn(){
+		
+		//TODO - add sliders for minion choice
+		
 	}
 	
 </script>
@@ -115,9 +169,9 @@ welcome
 	<!-- Add buttons to a group with 'name' attribute -->
 	<!-- i.e. only one radio button can be selected at a time -->
 	Trains
-	<input onclick="trainSelect()" type="radio" name="trainsAndTanks">
+	<input onclick="trainRadioSelect()" type="radio" name="trainsAndTanks">
 	Tanks
-	<input onclick="tankSelect()" type="radio" name="trainsAndTanks">
+	<input onclick="tankRadioSelect()" type="radio" name="trainsAndTanks">
 	
 <form action="#" method="post">
 	Select Number of Trains (0-5):
@@ -131,11 +185,12 @@ welcome
 
 	<!-- add reset button -->
 	<!-- run reset function when clicked -->
-	<button onclick="reset()">Reset</button>
+	<button onclick="resetBtn()">Reset</button>
 	
 	<!-- add confirm button -->
-	<!-- TODO -- add confirm button functionality -->
-	<button>Confirm</button>
+	<!-- run confirm function when selected -->
+	<!-- button is disabled until a vehicle choice is made -->
+	<button onclick="confirmBtn()" id = "confirm" disabled>Confirm</button>
 
 </body>
 </html>


### PR DESCRIPTION
Instead of repeating code three times in the reset function, two functions were created that is run by the reset function. An additional function was added to enable the confirm button.

The confirm button was disabled when the page first loads, then enabled when a vehicle selection is made. This is to avoid error checking if the user selects the confirm button on an illegal selection (i.e. the user cannot choose both trains and tanks; only one selection is allowed).